### PR TITLE
fix: add missing aws variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,8 @@ variable "prefix" {
 variable "prefix_restriction" {
   default = ""
 }
+
+variable "aws" {
+  type    = any
+  default = {}
+}


### PR DESCRIPTION
Missing aws variable lead to this error : 

> on ecr.tf line 65, in resource "aws_iam_policy" "ecr_user":
>   65:       "arn:aws:ecr:${var.aws["region"]}:${data.aws_caller_identity.current.account_id}:repository/${var.prefix_restriction}${var.prefix_restriction != "" ? "/" : ""}*"

